### PR TITLE
missing language for event_desc_loginpre

### DIFF
--- a/admin/lang/en_US.php
+++ b/admin/lang/en_US.php
@@ -468,6 +468,7 @@ $lang['event_desc_edituserpre'] = "Sent before edits to a user are saved";
 $lang['event_desc_globalcontentpostcompile'] = "Sent after a global content block has been processed by Smarty";
 $lang['event_desc_globalcontentprecompile'] = "Sent before a global content block is sent to Smarty for processing";
 $lang['event_desc_loginfailed'] = "Sent after a user failed to login into the Admin panel";
+$lang['event_desc_loginstart'] = "Sent when login request is started";
 $lang['event_desc_loginpre'] = "Sent when a user submits the login form in the Admin panel";
 $lang['event_desc_loginpost'] = "Sent after a user logs into the Admin panel";
 $lang['event_desc_logoutpost'] = "Sent after a user logs out of the Admin panel";


### PR DESCRIPTION
Event Manager was missing language string for LoginPre in admin\lang\en_US.php
Also added new LoginStart language for the new Core::LoginStart hook event