### PR TITLE
ModuleManager/v2.1.10

### DIFF
--- a/lib/plugins/modifier.localedate_format.php
+++ b/lib/plugins/modifier.localedate_format.php
@@ -228,15 +228,15 @@ function localedate_ise ($st, $mode)
         case "\6": // date without time
             $fmt = nl_langinfo(D_FMT);
             $fmt = localedate_adjust($fmt);
-            return date($fmt);
+            return date($fmt, $st);
         case "\7": // time without date
             $fmt = nl_langinfo(T_FMT);
             $fmt = localedate_adjust($fmt);
-            return date($fmt);
+            return date($fmt, $st);
         case "\x8": // date and time
             $fmt = nl_langinfo(D_T_FMT);
             $fmt = localedate_adjust($fmt);
-            return date($fmt);
+            return date($fmt, $st);
         case "\x0e": // am/pm, upper-case
         case "\x0f": // am/pm, lower-case
             $s = date('A', $st);

--- a/modules/ModuleManager/ModuleManager.module.php
+++ b/modules/ModuleManager/ModuleManager.module.php
@@ -40,11 +40,11 @@ define('MINIMUM_REPOSITORY_VERSION','1.5');
 
 class ModuleManager extends CMSModule
 {
-  const _dflt_request_url = 'https://www.cmsmadesimple.org/ModuleRepository/request/v2/';
+  const _dflt_request_url = 'https://api.cmsmadesimple.org/ModuleRepository/request/v2/';
 
   function GetName() { return get_class($this); }
   function GetFriendlyName() { return $this->Lang('friendlyname'); }
-  function GetVersion() { return '2.1.9'; }
+  function GetVersion() { return '2.1.10'; }
   function GetHelp() { return $this->Lang('help'); }
   function GetAuthor() { return 'calguy1000'; }
   function GetAuthorEmail() { return 'calguy1000@hotmail.com'; }

--- a/modules/ModuleManager/action.setprefs.php
+++ b/modules/ModuleManager/action.setprefs.php
@@ -47,6 +47,7 @@ if( isset($config['developer_mode']) && !empty($params['reseturl']) ) {
 if( isset($params['dl_chunksize']) ) $this->SetPreference('dl_chunksize',(int)trim($params['dl_chunksize']));
 $latestdepends = (int)get_parameter_value($params,'latestdepends');
 $this->SetPreference('latestdepends',$latestdepends);
+$this->SetPreference('show_beta',(int)get_parameter_value($params,'show_beta'));
 
 
 if( isset($config['developer_mode']) ) {

--- a/modules/ModuleManager/function.admin_modules_tab.php
+++ b/modules/ModuleManager/function.admin_modules_tab.php
@@ -107,6 +107,7 @@ if( count( $data ) ) {
       $onerow->$key = $value;
     }
     $onerow->name = $this->CreateLink( $id, 'modulelist', $returnid, $row['name'], array('name'=>$row['name']));
+    $onerow->rawname = $row['name'];
     $onerow->version = $row['version'];
     $onerow->help_url = $this->create_url( $id, 'modulehelp', $returnid,
 					   array('name' => $row['name'],'version' => $row['version'],'filename' => $row['filename']));

--- a/modules/ModuleManager/function.admin_prefs_tab.php
+++ b/modules/ModuleManager/function.admin_prefs_tab.php
@@ -45,6 +45,7 @@ if( isset($config['developer_mode']) ) {
 $smarty->assign('dl_chunksize',$this->GetPreference('dl_chunksize',256));
 $smarty->assign('latestdepends',$this->GetPreference('latestdepends',1));
 $smarty->assign('allowuninstall',$this->GetPreference('allowuninstall',0));
+$smarty->assign('show_beta',$this->GetPreference('show_beta',0));
 
 echo $this->ProcessTemplate('adminprefs.tpl');
 

--- a/modules/ModuleManager/function.newversionstab.php
+++ b/modules/ModuleManager/function.newversionstab.php
@@ -73,6 +73,7 @@ if( !empty($newversions) ) {
 				$onerow->age = modmgr_utils::get_status($row['date']);
 
 				$onerow->name = $this->CreateLink( $id, 'modulelist', $returnid, $row['name'], array('name'=>$row['name']));
+				$onerow->rawname = $row['name'];
 				$onerow->version = $row['version'];
 
 				$onerow->help_url = $this->create_url($id,'modulehelp',$returnid,

--- a/modules/ModuleManager/function.search.php
+++ b/modules/ModuleManager/function.search.php
@@ -95,6 +95,7 @@ if( isset($params['submit']) ) {
                 $obj->$k = $v;
             }
             $obj->name = $this->CreateLink( $id, 'modulelist', $returnid, $row['name'],array('name'=>$row['name']));
+            $obj->rawname = $row['name'];
             $obj->version = $row['version'];
             $obj->help_url = $this->create_url( $id, 'modulehelp', $returnid,
                                                 array('name'=>$row['name'],'version'=>$row['version'],'filename'=>$row['filename']) );

--- a/modules/ModuleManager/lang/en_US.php
+++ b/modules/ModuleManager/lang/en_US.php
@@ -118,6 +118,8 @@ $lang['help_dl_chunksize'] = 'This parameter specifies the size <em>(in kilobyte
 $lang['help_latestdepends'] = 'When installing a module with dependencies, this will ensure that the newest version of a dependent module is installed';
 $lang['help_mm_importxml'] = 'This form allows importing a module XML file that you received from another user, or downloaded from the <a class="external" href="http://dev.cmsmadesimple.org" target="_blank">CMSMS Forge</a>';
 
+$lang['help_show_beta'] = 'When enabled, modules with beta, alpha, or rc in their version will be displayed in the module listings';
+
 // I
 $lang['importxml'] = 'Import Module';
 $lang['incompatible'] = 'Incompatible';
@@ -202,6 +204,7 @@ $lang['status'] = 'Status';
 $lang['status_db_newer'] = 'The version number stored in the database is greater than the one in the module.';
 $lang['status_need_upgrade'] = 'The upgrade routine needs to be run on this module';
 $lang['status_newer_available'] = 'A newer version of this module is available in the repository';
+$lang['show_beta'] = 'Show beta/pre-release modules';
 $lang['statustext'] = 'Status/Action';
 $lang['status_installed'] = 'This module is currently installed and available for use.';
 $lang['submit'] = 'Submit';

--- a/modules/ModuleManager/lib/class.modmgr_cached_request.php
+++ b/modules/ModuleManager/lib/class.modmgr_cached_request.php
@@ -50,7 +50,7 @@ final class modmgr_cached_request
     }
   }
 
-  public function execute($target = '',$data = array(), $age = '')
+  public function execute($target = '',$data = array(), $age = '', $method = 'GET')
   {
     $mod = cms_utils::get_module('ModuleManager');
     $config = cmsms()->GetConfig();
@@ -71,7 +71,7 @@ final class modmgr_cached_request
         // execute the request
         $req = new cms_http_request();
         if( $this->_timeout ) $req->setTimeout($this->_timeout);
-        $req->execute($target,'','POST',$data);
+        $req->execute($target,'',$method,$data);
         $this->_status = $req->getStatus();
         $this->_result = $req->getResult();
 

--- a/modules/ModuleManager/lib/class.modmgr_utils.php
+++ b/modules/ModuleManager/lib/class.modmgr_utils.php
@@ -99,6 +99,17 @@ final class modmgr_utils
     {
         if( !is_array($xmldetails) ) return;
 
+        // Filter out beta/pre-release modules unless preference is enabled
+        $mod = cms_utils::get_module('ModuleManager');
+        if( !$mod->GetPreference('show_beta',0) ) {
+            $xmldetails = array_filter($xmldetails, function($det) {
+                $ver = isset($det['version']) ? strtolower($det['version']) : '';
+                $fn = isset($det['filename']) ? strtolower($det['filename']) : '';
+                return !preg_match('/(alpha|beta|rc|dev)/', $ver . $fn);
+            });
+            $xmldetails = array_values($xmldetails);
+        }
+
         // sort
         uasort( $xmldetails, array('modmgr_utils','uasort_cmp_details') );
 

--- a/modules/ModuleManager/lib/class.modmgr_utils.php
+++ b/modules/ModuleManager/lib/class.modmgr_utils.php
@@ -230,7 +230,7 @@ final class modmgr_utils
         $ts = strtotime($date);
         $stale_ts = strtotime('-2 years');
         $warn_ts = strtotime('-18 months');
-        $new_ts = strtotime('-1 month');
+        $new_ts = strtotime('-3 months');
         if( $ts <= $stale_ts ) return 'stale';
         if( $ts <= $warn_ts ) return 'warn';
         if( $ts >= $new_ts ) return 'new';

--- a/modules/ModuleManager/lib/class.modmgr_utils.php
+++ b/modules/ModuleManager/lib/class.modmgr_utils.php
@@ -200,7 +200,7 @@ final class modmgr_utils
         if( $url ) {
             $url .= '/version';
             $req = new modmgr_cached_request($url);
-            $req->setTimeout(3);
+            $req->setTimeout(10);
             $req->execute($url);
             if( ($status = $req->getStatus()) == 200 ) {
                 $tmp = $req->getResult();

--- a/modules/ModuleManager/lib/class.modulerep_client.php
+++ b/modules/ModuleManager/lib/class.modulerep_client.php
@@ -195,7 +195,7 @@ final class modulerep_client
                 // downloading the whole file at one shot.
                 $url .= '/modulexml';
                 $req = new cms_http_request();
-                $req->execute($url,'','POST',array('name'=>$xmlfile));
+                $req->execute($url,'','GET',array('name'=>$xmlfile));
                 $status = $req->GetStatus();
                 $result = $req->GetResult();
                 if( $status != 200 || $result == '' ) {
@@ -214,7 +214,7 @@ final class modulerep_client
             $nchunks = (int)ceil($size / $chunksize);
             $req = new cms_http_request();
             for( $i = 0; $i < $nchunks; $i++ ) {
-                $req->execute($url,'','POST', array('name'=>$xmlfile,'partnum'=>$i,'sizekb'=>$orig_chunksize));
+                $req->execute($url,'','GET', array('name'=>$xmlfile,'partnum'=>$i,'sizekb'=>$orig_chunksize));
                 $status = $req->GetStatus();
                 $result = $req->GetResult();
                 if( $status != 200 || $result == '' ) {
@@ -270,7 +270,7 @@ final class modulerep_client
         $url .= '/modulesearch';
 
         $req = new modmgr_cached_request();
-        $req->execute($url,array('json'=>json_encode($qparms)));
+        $req->execute($url,array('json'=>json_encode($qparms)),'','POST');
         $status = $req->getStatus();
         $result = $req->getResult();
         if( $status == 200 && $result == ''  ) return array(TRUE,null); // no results.

--- a/modules/ModuleManager/templates/admin_installed.tpl
+++ b/modules/ModuleManager/templates/admin_installed.tpl
@@ -73,6 +73,7 @@ $(document).ready(function(){
   <thead>
     <tr>
       <th></th>
+      <th></th>
       <th>{$ModuleManager->Lang('nametext')}</th>
       <th><span title="{$ModuleManager->Lang('title_moduleversion')}">{$ModuleManager->Lang('vertext')}</span></th>
       <th><span title="{$ModuleManager->Lang('title_modulestatus')}">{$ModuleManager->Lang('status')}</span></th>
@@ -91,6 +92,9 @@ $(document).ready(function(){
            {if $item.e_status == 'newer_available'}{$star_img}{/if}
 	   {if $item.missing_deps || $item.notavailable}{$missingdep_img}{/if}
            {if $item.deprecated}{$deprecated_img}{/if}
+      </td>
+      <td style="text-align:center;">
+          <img src="https://cmsms-forge.s3.amazonaws.com/modules/{$item.name}/icon.png" alt="" style="width:24px;height:24px;" onerror="this.style.display='none'"/>
       </td>
       <td>
           {if !$item.installed || $item.e_status == 'need_upgrade'}

--- a/modules/ModuleManager/templates/admin_search_tab.tpl
+++ b/modules/ModuleManager/templates/admin_search_tab.tpl
@@ -48,6 +48,7 @@ $(document).ready(function(){
 	<thead>
 		<tr>
 			<th></th>
+			<th></th>
 			<th>{$ModuleManager->Lang('nametext')}</th>
 			<th><span title="{$ModuleManager->Lang('title_modulelastversion')}">{$ModuleManager->Lang('vertext')}</span></th>
 			<th><span title="{$ModuleManager->Lang('title_modulelastreleasedate')}">{$ModuleManager->Lang('releasedate')}</span></th>
@@ -63,6 +64,7 @@ $(document).ready(function(){
 		{cycle values="row1,row2" assign='rowclass'}
 			<tr class="{$rowclass}" {if $entry->age=='new'}style="font-weight: bold;"{/if}>
 			<td>{get_module_status_icon status=$entry->age}</td>
+			<td style="text-align:center;"><img src="https://cmsms-forge.s3.amazonaws.com/modules/{$entry->rawname}/icon.png" alt="" style="width:24px;height:24px;" onerror="this.style.display='none'"/></td>
 			<td><span title="{$entry->description|strip_tags|cms_escape}">{$entry->name}</span></td>
 			<td>{$entry->version}</td>
 			<td>{$entry->date|localedate_format:'%x'}</td>

--- a/modules/ModuleManager/templates/adminpanel.tpl
+++ b/modules/ModuleManager/templates/adminpanel.tpl
@@ -41,13 +41,14 @@
 			<th>&nbsp;</th>
 			<th>&nbsp;</th>
 			<th>&nbsp;</th>
+			<th>&nbsp;</th>
 		</tr>
 	</thead>
 	<tbody>
 	{foreach from=$items item=entry}
 		{cycle values="row1,row2" assign='rowclass'}
 			<tr class="{$rowclass}" {if $entry->age=='new'}style="font-weight: bold;"{/if}>
-			<td>{get_module_status_icon status=$entry->age}</td>
+			<td style="text-align:center;"><img src="https://cmsms-forge.s3.amazonaws.com/modules/{$entry->rawname}/icon.png" alt="" style="width:24px;height:24px;" onerror="this.style.display='none'"/></td>
 			<td><span title="{$entry->description|strip_tags|cms_escape}">{$entry->name}</span></td>
 			<td>{$entry->version}</td>
 			<td>{$entry->date|localedate_format:'%x'}</td>
@@ -61,6 +62,7 @@
 			<td><a href="{$entry->depends_url}" title="{$ModuleManager->Lang('title_moduledepends')}">{$ModuleManager->Lang('dependstxt')}</a></td>
 			<td><a href="{$entry->help_url}" title="{$ModuleManager->Lang('title_modulehelp')}">{$ModuleManager->Lang('helptxt')}</a></td>
 			<td><a href="{$entry->about_url}" title="{$ModuleManager->Lang('title_moduleabout')}">{$ModuleManager->Lang('abouttxt')}</a></td>
+			<td>{get_module_status_icon status=$entry->age}</td>
 		</tr>
 	{/foreach}
 	</tbody>

--- a/modules/ModuleManager/templates/adminpanel.tpl
+++ b/modules/ModuleManager/templates/adminpanel.tpl
@@ -19,9 +19,9 @@
 {function get_module_status_icon}
 {strip}
 {if $status == 'stale'}
-{$stale_img}
+{*$stale_img*}
 {elseif $status == 'warn'}
-{$warn_img}
+{*$warn_img*}
 {elseif $status == 'new'}
 {$new_img}
 {/if}

--- a/modules/ModuleManager/templates/adminprefs.tpl
+++ b/modules/ModuleManager/templates/adminprefs.tpl
@@ -45,6 +45,13 @@ $(document).ready(function(){
     </p>
   </div>
 
+  <div class="pageoverflow">
+    <p class="pagetext"><label for="show_beta">{$ModuleManager->Lang('show_beta')}:</label>&nbsp;{cms_help key2='help_show_beta' title=$ModuleManager->Lang('show_beta')}</p>
+    <p class="pageinput">
+      <select id="show_beta" name="{$actionid}show_beta">{cms_yesno selected=$show_beta}</select>
+    </p>
+  </div>
+
 {if isset($developer_mode)}
   <div class="pageoverflow">
     <p class="pagetext"><label for="allowuninstall">{$ModuleManager->Lang('allowuninstall')}:</label>&nbsp;{cms_help key2='help_allowuninstall' title=$ModuleManager->Lang('allowuninstall')}</p>

--- a/modules/ModuleManager/templates/newversionstab.tpl
+++ b/modules/ModuleManager/templates/newversionstab.tpl
@@ -25,6 +25,7 @@
 	<thead>
 		<tr>
 			<th></th>
+			<th></th>
 			<th>{$nametext}</th>
 			<th><span title="{$ModuleManager->Lang('title_newmoduleversion')}">{$vertext}</span></th>
 			<th><span title="{$ModuleManager->Lang('title_yourmoduledate')}">{$ModuleManager->Lang('releasedate')}</span></th>
@@ -42,6 +43,7 @@
 	{cycle values="row1,row2" assign='rowclass'}
 	<tr class="{$rowclass}" {if $entry->age=='new'}style="font-weight: bold;"{/if}>
 		<td>{get_module_status_icon status=$entry->age}</td>
+		<td style="text-align:center;"><img src="https://cmsms-forge.s3.amazonaws.com/modules/{$entry->rawname}/icon.png" alt="" style="width:24px;height:24px;" onerror="this.style.display='none'"/></td>
 		<td>
 			<span title="{$entry->description|strip_tags|cms_escape}">{$entry->name|default:''}</span>
 			{if $entry->error}<br/><span style="color: red;">{$entry->error}</span>{/if}


### PR DESCRIPTION
ModuleManager/v2.1.10:

1) dflt_request_url = api.cmsmadesimple.org instead of www.cmsmadesimple.org
2) removed error and warning labels from older modules. Being most old.
3) updated date column error in displayed format.

<img width="1036" height="688" alt="image" src="https://github.com/user-attachments/assets/4a4354a7-1340-4bef-8ac8-afde3454779d" />
