### PR TITLE
News module: add CLI commands for articles, categories, and field def…

### DIFF
--- a/modules/News/News.module.php
+++ b/modules/News/News.module.php
@@ -353,8 +353,32 @@ class News extends CMSModule
         case CmsCoreCapabilities::ADMINSEARCH:
         case CmsCoreCapabilities::TASKS:
             return TRUE;
+        case 'clicommands':
+            return TRUE;
         }
         return FALSE;
+    }
+
+    public function get_cli_commands($app)
+    {
+        $dir = __DIR__ . '/lib/Commands/';
+        foreach (glob($dir . 'class.*.php') as $file) {
+            require_once $file;
+        }
+        return [
+            new \News\Commands\ArticleListCommand($app),
+            new \News\Commands\ArticleCreateCommand($app),
+            new \News\Commands\ArticleEditCommand($app),
+            new \News\Commands\ArticleDeleteCommand($app),
+            new \News\Commands\CategoryListCommand($app),
+            new \News\Commands\CategoryCreateCommand($app),
+            new \News\Commands\CategoryEditCommand($app),
+            new \News\Commands\CategoryDeleteCommand($app),
+            new \News\Commands\FielddefListCommand($app),
+            new \News\Commands\FielddefCreateCommand($app),
+            new \News\Commands\FielddefEditCommand($app),
+            new \News\Commands\FielddefDeleteCommand($app),
+        ];
     }
 
     public function get_adminsearch_slaves()

--- a/modules/News/lib/Commands/class.ArticleCreateCommand.php
+++ b/modules/News/lib/Commands/class.ArticleCreateCommand.php
@@ -1,0 +1,131 @@
+<?php
+namespace News\Commands;
+use CMSMS\CLI\App;
+use CMSMS\CLI\GetOptExt\Command;
+use CMSMS\CLI\GetOptExt\Option;
+use CMSMS\CLI\GetOptExt\GetOpt;
+use GetOpt\Operand;
+
+class ArticleCreateCommand extends Command
+{
+    public function __construct(App $app)
+    {
+        parent::__construct($app, 'news-create');
+        $this->addOperand(new Operand('title', Operand::REQUIRED));
+        $this->addOption(Option::Create(null, 'content', GetOpt::REQUIRED_ARGUMENT)->setDescription('Article body (HTML)'));
+        $this->addOption(Option::Create(null, 'file', GetOpt::REQUIRED_ARGUMENT)->setDescription('Read content from file'));
+        $this->addOption(Option::Create(null, 'summary', GetOpt::REQUIRED_ARGUMENT)->setDescription('Article summary'));
+        $this->addOption(Option::Create(null, 'url', GetOpt::REQUIRED_ARGUMENT)->setDescription('Pretty URL slug'));
+        $this->addOption(Option::Create(null, 'category', GetOpt::REQUIRED_ARGUMENT)->setDescription('Category name (default: General)'));
+        $this->addOption(Option::Create(null, 'status', GetOpt::REQUIRED_ARGUMENT)->setDescription('Status: published or draft (default: published)'));
+        $this->addOption(Option::Create(null, 'news-date', GetOpt::REQUIRED_ARGUMENT)->setDescription('Publish date (Y-m-d H:i:s, default: now)'));
+        $this->addOption(Option::Create(null, 'start-date', GetOpt::REQUIRED_ARGUMENT)->setDescription('Start date (Y-m-d H:i:s)'));
+        $this->addOption(Option::Create(null, 'end-date', GetOpt::REQUIRED_ARGUMENT)->setDescription('End date (Y-m-d H:i:s)'));
+        $this->addOption(Option::Create(null, 'extra', GetOpt::REQUIRED_ARGUMENT)->setDescription('Extra field value'));
+        $this->addOption(Option::Create(null, 'searchable', GetOpt::REQUIRED_ARGUMENT)->setDescription('Searchable: 1 or 0 (default: 1)'));
+        $this->addOption(Option::Create(null, 'set-field', GetOpt::MULTIPLE_ARGUMENT)->setDescription('Set custom field: name=value (repeatable)'));
+    }
+
+    public function getShortDescription()
+    {
+        return 'Create a News article';
+    }
+
+    public function getLongDescription()
+    {
+        return 'Create a new News article with title, content, category, URL, and custom field values';
+    }
+
+    public function handle()
+    {
+        $title = trim($this->getOperand('title')->getValue());
+        $content = $this->getOption('content')->getValue();
+        $file = $this->getOption('file')->getValue();
+        $summary = $this->getOption('summary')->getValue();
+        $url = $this->getOption('url')->getValue();
+        $category = $this->getOption('category')->getValue();
+        $status = $this->getOption('status')->getValue();
+        $news_date = $this->getOption('news-date')->getValue();
+        $start_date = $this->getOption('start-date')->getValue();
+        $end_date = $this->getOption('end-date')->getValue();
+        $extra = $this->getOption('extra')->getValue();
+        $searchable = $this->getOption('searchable')->getValue();
+        $fields = $this->getOption('set-field')->getValue();
+
+        // Content from file
+        if ($file) {
+            if (!is_file($file)) throw new \RuntimeException("File not found: $file");
+            $content = file_get_contents($file);
+        }
+
+        $db = \cmsms()->GetDb();
+        $prefix = \cms_db_prefix();
+
+        // Resolve category
+        $cat_id = 1; // Default: General
+        if ($category) {
+            $found = $db->GetOne("SELECT news_category_id FROM {$prefix}module_news_categories WHERE news_category_name = ?", [$category]);
+            if (!$found) throw new \RuntimeException("Category '$category' not found");
+            $cat_id = (int) $found;
+        }
+
+        // Defaults
+        if (!$status) $status = 'published';
+        if (!$url) $url = munge_string_to_url($title, true);
+        if ($searchable === null) $searchable = 1;
+        $now = $db->DbTimeStamp(time());
+
+        // Generate ID
+        $article_id = $db->GenID($prefix . "module_news_seq");
+
+        // Build news_date
+        $news_date_sql = $news_date ? $db->DbTimeStamp(strtotime($news_date)) : $now;
+        $start_date_sql = $start_date ? $db->DbTimeStamp(strtotime($start_date)) : 'NULL';
+        $end_date_sql = $end_date ? $db->DbTimeStamp(strtotime($end_date)) : 'NULL';
+
+        $sql = "INSERT INTO {$prefix}module_news
+                (news_id, news_category_id, news_title, news_data, news_date, summary, start_time, end_time, status, news_extra, news_url, searchable, author_id, create_date, modified_date)
+                VALUES (?, ?, ?, ?, $news_date_sql, ?, $start_date_sql, $end_date_sql, ?, ?, ?, ?, ?, $now, $now)";
+
+        $params = [
+            $article_id,
+            $cat_id,
+            $title,
+            $content ?: '',
+            $summary ?: '',
+            $status,
+            $extra ?: '',
+            $url,
+            (int) $searchable,
+            1 // author_id (admin)
+        ];
+
+        $dbr = $db->Execute($sql, $params);
+        if (!$dbr) throw new \RuntimeException("Failed to insert article: " . $db->ErrorMsg());
+
+        // Set custom field values
+        if (!empty($fields)) {
+            foreach ($fields as $fv) {
+                $parts = explode('=', $fv, 2);
+                if (count($parts) !== 2) continue;
+                $fd_name = trim($parts[0]);
+                $fd_value = trim($parts[1]);
+
+                $fd_id = $db->GetOne("SELECT id FROM {$prefix}module_news_fielddefs WHERE name = ?", [$fd_name]);
+                if (!$fd_id) {
+                    echo "WARNING: Custom field '$fd_name' not found, skipping.\n";
+                    continue;
+                }
+                $db->Execute("INSERT INTO {$prefix}module_news_fieldvals (news_id, fielddef_id, value, create_date, modified_date) VALUES (?, ?, ?, $now, $now)",
+                    [$article_id, (int) $fd_id, $fd_value]);
+            }
+        }
+
+        // Register static route
+        if ($url && $status === 'published') {
+            \news_admin_ops::register_static_route($url, $article_id);
+        }
+
+        echo "Created article $article_id ($url)\n";
+    }
+}

--- a/modules/News/lib/Commands/class.ArticleDeleteCommand.php
+++ b/modules/News/lib/Commands/class.ArticleDeleteCommand.php
@@ -1,0 +1,57 @@
+<?php
+namespace News\Commands;
+use CMSMS\CLI\App;
+use CMSMS\CLI\GetOptExt\Command;
+use CMSMS\CLI\GetOptExt\Option;
+use CMSMS\CLI\GetOptExt\GetOpt;
+use GetOpt\Operand;
+
+class ArticleDeleteCommand extends Command
+{
+    public function __construct(App $app)
+    {
+        parent::__construct($app, 'news-delete');
+        $this->addOperand(new Operand('article', Operand::REQUIRED));
+    }
+
+    public function getShortDescription()
+    {
+        return 'Delete a News article';
+    }
+
+    public function getLongDescription()
+    {
+        return 'Delete a News article by ID or URL slug. Removes the article, its field values, and its static route.';
+    }
+
+    public function handle()
+    {
+        $article = trim($this->getOperand('article')->getValue());
+
+        $db = \cmsms()->GetDb();
+        $prefix = \cms_db_prefix();
+
+        // Resolve article by ID or URL slug
+        if (is_numeric($article)) {
+            $row = $db->GetRow("SELECT news_id, news_title, news_url FROM {$prefix}module_news WHERE news_id = ?", [(int) $article]);
+        } else {
+            $row = $db->GetRow("SELECT news_id, news_title, news_url FROM {$prefix}module_news WHERE news_url = ?", [$article]);
+        }
+        if (!$row) throw new \RuntimeException("Article '$article' not found");
+
+        $article_id = (int) $row['news_id'];
+
+        // Delete field values
+        $db->Execute("DELETE FROM {$prefix}module_news_fieldvals WHERE news_id = ?", [$article_id]);
+
+        // Delete article
+        $db->Execute("DELETE FROM {$prefix}module_news WHERE news_id = ?", [$article_id]);
+
+        // Remove static route
+        if ($row['news_url']) {
+            \cms_route_manager::del_static($row['news_url'], 'News');
+        }
+
+        echo "Deleted article $article_id ({$row['news_title']})\n";
+    }
+}

--- a/modules/News/lib/Commands/class.ArticleEditCommand.php
+++ b/modules/News/lib/Commands/class.ArticleEditCommand.php
@@ -1,0 +1,143 @@
+<?php
+namespace News\Commands;
+use CMSMS\CLI\App;
+use CMSMS\CLI\GetOptExt\Command;
+use CMSMS\CLI\GetOptExt\Option;
+use CMSMS\CLI\GetOptExt\GetOpt;
+use GetOpt\Operand;
+
+class ArticleEditCommand extends Command
+{
+    public function __construct(App $app)
+    {
+        parent::__construct($app, 'news-edit');
+        $this->addOperand(new Operand('article', Operand::REQUIRED));
+        $this->addOption(Option::Create(null, 'title', GetOpt::REQUIRED_ARGUMENT)->setDescription('Set article title'));
+        $this->addOption(Option::Create(null, 'content', GetOpt::REQUIRED_ARGUMENT)->setDescription('Set article body (HTML)'));
+        $this->addOption(Option::Create(null, 'file', GetOpt::REQUIRED_ARGUMENT)->setDescription('Read content from file'));
+        $this->addOption(Option::Create(null, 'summary', GetOpt::REQUIRED_ARGUMENT)->setDescription('Set summary'));
+        $this->addOption(Option::Create(null, 'url', GetOpt::REQUIRED_ARGUMENT)->setDescription('Set pretty URL slug'));
+        $this->addOption(Option::Create(null, 'category', GetOpt::REQUIRED_ARGUMENT)->setDescription('Set category name'));
+        $this->addOption(Option::Create(null, 'status', GetOpt::REQUIRED_ARGUMENT)->setDescription('Set status: published or draft'));
+        $this->addOption(Option::Create(null, 'news-date', GetOpt::REQUIRED_ARGUMENT)->setDescription('Set publish date (Y-m-d H:i:s)'));
+        $this->addOption(Option::Create(null, 'start-date', GetOpt::REQUIRED_ARGUMENT)->setDescription('Set start date (Y-m-d H:i:s)'));
+        $this->addOption(Option::Create(null, 'end-date', GetOpt::REQUIRED_ARGUMENT)->setDescription('Set end date (Y-m-d H:i:s)'));
+        $this->addOption(Option::Create(null, 'extra', GetOpt::REQUIRED_ARGUMENT)->setDescription('Set extra field'));
+        $this->addOption(Option::Create(null, 'searchable', GetOpt::REQUIRED_ARGUMENT)->setDescription('Set searchable: 1 or 0'));
+        $this->addOption(Option::Create(null, 'set-field', GetOpt::MULTIPLE_ARGUMENT)->setDescription('Set custom field: name=value (repeatable)'));
+    }
+
+    public function getShortDescription()
+    {
+        return 'Edit a News article';
+    }
+
+    public function getLongDescription()
+    {
+        return 'Update an existing News article by ID or URL slug. Specify fields to change.';
+    }
+
+    public function handle()
+    {
+        $article = trim($this->getOperand('article')->getValue());
+        $new_title = $this->getOption('title')->getValue();
+        $content = $this->getOption('content')->getValue();
+        $file = $this->getOption('file')->getValue();
+        $summary = $this->getOption('summary')->getValue();
+        $url = $this->getOption('url')->getValue();
+        $category = $this->getOption('category')->getValue();
+        $status = $this->getOption('status')->getValue();
+        $news_date = $this->getOption('news-date')->getValue();
+        $start_date = $this->getOption('start-date')->getValue();
+        $end_date = $this->getOption('end-date')->getValue();
+        $extra = $this->getOption('extra')->getValue();
+        $searchable = $this->getOption('searchable')->getValue();
+        $fields = $this->getOption('set-field')->getValue();
+
+        // Content from file
+        if ($file) {
+            if (!is_file($file)) throw new \RuntimeException("File not found: $file");
+            $content = file_get_contents($file);
+        }
+
+        $db = \cmsms()->GetDb();
+        $prefix = \cms_db_prefix();
+
+        // Resolve article by ID or URL slug
+        if (is_numeric($article)) {
+            $row = $db->GetRow("SELECT news_id, news_title, news_url FROM {$prefix}module_news WHERE news_id = ?", [(int) $article]);
+        } else {
+            $row = $db->GetRow("SELECT news_id, news_title, news_url FROM {$prefix}module_news WHERE news_url = ?", [$article]);
+        }
+        if (!$row) throw new \RuntimeException("Article '$article' not found");
+        $article_id = (int) $row['news_id'];
+
+        // Build UPDATE
+        $updates = [];
+        $params = [];
+        $now = $db->DbTimeStamp(time());
+
+        if ($new_title !== null) { $updates[] = 'news_title = ?'; $params[] = $new_title; }
+        if ($content !== null) { $updates[] = 'news_data = ?'; $params[] = $content; }
+        if ($summary !== null) { $updates[] = 'summary = ?'; $params[] = $summary; }
+        if ($url !== null) { $updates[] = 'news_url = ?'; $params[] = $url; }
+        if ($status !== null) { $updates[] = 'status = ?'; $params[] = $status; }
+        if ($extra !== null) { $updates[] = 'news_extra = ?'; $params[] = $extra; }
+        if ($searchable !== null) { $updates[] = 'searchable = ?'; $params[] = (int) $searchable; }
+
+        if ($category) {
+            $cat_id = $db->GetOne("SELECT news_category_id FROM {$prefix}module_news_categories WHERE news_category_name = ?", [$category]);
+            if (!$cat_id) throw new \RuntimeException("Category '$category' not found");
+            $updates[] = 'news_category_id = ?';
+            $params[] = (int) $cat_id;
+        }
+
+        if ($news_date) { $updates[] = "news_date = " . $db->DbTimeStamp(strtotime($news_date)); }
+        if ($start_date) { $updates[] = "start_time = " . $db->DbTimeStamp(strtotime($start_date)); }
+        if ($end_date) { $updates[] = "end_time = " . $db->DbTimeStamp(strtotime($end_date)); }
+
+        if (empty($updates) && empty($fields)) {
+            throw new \RuntimeException('Please specify at least one option to change');
+        }
+
+        if (!empty($updates)) {
+            $updates[] = "modified_date = $now";
+            $params[] = $article_id;
+            $sql = "UPDATE {$prefix}module_news SET " . implode(', ', $updates) . " WHERE news_id = ?";
+            $db->Execute($sql, $params);
+        }
+
+        // Set custom field values
+        if (!empty($fields)) {
+            foreach ($fields as $fv) {
+                $parts = explode('=', $fv, 2);
+                if (count($parts) !== 2) continue;
+                $fd_name = trim($parts[0]);
+                $fd_value = trim($parts[1]);
+
+                $fd_id = $db->GetOne("SELECT id FROM {$prefix}module_news_fielddefs WHERE name = ?", [$fd_name]);
+                if (!$fd_id) {
+                    echo "WARNING: Custom field '$fd_name' not found, skipping.\n";
+                    continue;
+                }
+
+                $existing = $db->GetOne("SELECT value FROM {$prefix}module_news_fieldvals WHERE news_id = ? AND fielddef_id = ?", [$article_id, (int) $fd_id]);
+                if ($existing !== false && $existing !== null) {
+                    $db->Execute("UPDATE {$prefix}module_news_fieldvals SET value = ?, modified_date = $now WHERE news_id = ? AND fielddef_id = ?",
+                        [$fd_value, $article_id, (int) $fd_id]);
+                } else {
+                    $db->Execute("INSERT INTO {$prefix}module_news_fieldvals (news_id, fielddef_id, value, create_date, modified_date) VALUES (?, ?, ?, $now, $now)",
+                        [$article_id, (int) $fd_id, $fd_value]);
+                }
+            }
+        }
+
+        // Re-register route if URL changed
+        if ($url !== null && $url !== $row['news_url']) {
+            \cms_route_manager::del_static($row['news_url'], 'News');
+            \news_admin_ops::register_static_route($url, $article_id);
+        }
+
+        echo "Updated article $article_id\n";
+    }
+}

--- a/modules/News/lib/Commands/class.ArticleListCommand.php
+++ b/modules/News/lib/Commands/class.ArticleListCommand.php
@@ -1,0 +1,87 @@
+<?php
+namespace News\Commands;
+use CMSMS\CLI\App;
+use CMSMS\CLI\GetOptExt\Command;
+use CMSMS\CLI\GetOptExt\Option;
+use CMSMS\CLI\GetOptExt\GetOpt;
+
+class ArticleListCommand extends Command
+{
+    public function __construct(App $app)
+    {
+        parent::__construct($app, 'news-list');
+        $this->addOption(Option::Create(null, 'category', GetOpt::REQUIRED_ARGUMENT)->setDescription('Filter by category name'));
+        $this->addOption(Option::Create(null, 'status', GetOpt::REQUIRED_ARGUMENT)->setDescription('Filter by status: published, draft'));
+        $this->addOption(Option::Create(null, 'limit', GetOpt::REQUIRED_ARGUMENT)->setDescription('Max articles (default 50)'));
+        $this->addOption(Option::Create(null, 'output-json')->setDescription('Output in JSON format'));
+    }
+
+    public function getShortDescription()
+    {
+        return 'List News articles';
+    }
+
+    public function getLongDescription()
+    {
+        return 'Display a list of News articles with optional category and status filters';
+    }
+
+    public function handle()
+    {
+        $category = $this->getOption('category')->getValue();
+        $status = $this->getOption('status')->getValue();
+        $limit = (int) $this->getOption('limit')->getValue();
+        $json = $this->getOption('output-json')->getValue();
+
+        if ($limit < 1) $limit = 50;
+
+        $db = \cmsms()->GetDb();
+        $prefix = \cms_db_prefix();
+
+        $sql = "SELECT n.news_id, n.news_title, n.news_url, n.status, n.news_date, c.news_category_name AS category
+                FROM {$prefix}module_news n
+                LEFT JOIN {$prefix}module_news_categories c ON c.news_category_id = n.news_category_id
+                WHERE 1=1";
+        $params = [];
+
+        if ($category) {
+            $sql .= " AND c.news_category_name = ?";
+            $params[] = $category;
+        }
+        if ($status) {
+            $sql .= " AND n.status = ?";
+            $params[] = $status;
+        }
+
+        $sql .= " ORDER BY n.news_date DESC LIMIT $limit";
+        $rows = $db->GetArray($sql, $params);
+
+        if (empty($rows)) {
+            if (!$json) echo "No articles found.\n";
+            return;
+        }
+
+        if ($json) {
+            $out = [];
+            foreach ($rows as $row) {
+                $row['news_id'] = (int) $row['news_id'];
+                $out[] = $row;
+            }
+            echo json_encode($out, JSON_PRETTY_PRINT) . "\n";
+            return;
+        }
+
+        $fmt = "%-5s %-50s %-25s %-10s %-19s\n";
+        printf($fmt, 'ID', 'Title', 'URL', 'Status', 'Date');
+        printf($fmt, '--', '-----', '---', '------', '----');
+        foreach ($rows as $row) {
+            printf($fmt,
+                $row['news_id'],
+                substr($row['news_title'], 0, 50),
+                substr($row['news_url'], 0, 25),
+                $row['status'],
+                substr($row['news_date'], 0, 19)
+            );
+        }
+    }
+}

--- a/modules/News/lib/Commands/class.CategoryCreateCommand.php
+++ b/modules/News/lib/Commands/class.CategoryCreateCommand.php
@@ -1,0 +1,67 @@
+<?php
+namespace News\Commands;
+use CMSMS\CLI\App;
+use CMSMS\CLI\GetOptExt\Command;
+use CMSMS\CLI\GetOptExt\Option;
+use CMSMS\CLI\GetOptExt\GetOpt;
+use GetOpt\Operand;
+
+class CategoryCreateCommand extends Command
+{
+    public function __construct(App $app)
+    {
+        parent::__construct($app, 'news-category-create');
+        $this->addOperand(new Operand('name', Operand::REQUIRED));
+        $this->addOption(Option::Create(null, 'parent', GetOpt::REQUIRED_ARGUMENT)->setDescription('Parent category name or ID (default: root)'));
+    }
+
+    public function getShortDescription()
+    {
+        return 'Create a News category';
+    }
+
+    public function getLongDescription()
+    {
+        return 'Create a new News category with an optional parent';
+    }
+
+    public function handle()
+    {
+        $name = trim($this->getOperand('name')->getValue());
+        $parent = $this->getOption('parent')->getValue();
+
+        $db = \cmsms()->GetDb();
+        $prefix = \cms_db_prefix();
+
+        // Check duplicate
+        $exists = $db->GetOne("SELECT news_category_id FROM {$prefix}module_news_categories WHERE news_category_name = ?", [$name]);
+        if ($exists) throw new \RuntimeException("Category '$name' already exists (ID: $exists)");
+
+        // Resolve parent
+        $parent_id = -1;
+        if ($parent) {
+            if (is_numeric($parent)) {
+                $check = $db->GetOne("SELECT news_category_id FROM {$prefix}module_news_categories WHERE news_category_id = ?", [(int) $parent]);
+                if (!$check) throw new \RuntimeException("Parent category ID '$parent' not found");
+                $parent_id = (int) $parent;
+            } else {
+                $check = $db->GetOne("SELECT news_category_id FROM {$prefix}module_news_categories WHERE news_category_name = ?", [$parent]);
+                if (!$check) throw new \RuntimeException("Parent category '$parent' not found");
+                $parent_id = (int) $check;
+            }
+        }
+
+        $now = $db->DbTimeStamp(time());
+        $cat_id = $db->GenID($prefix . "module_news_categories_seq");
+
+        $db->Execute(
+            "INSERT INTO {$prefix}module_news_categories (news_category_id, news_category_name, parent_id, create_date, modified_date) VALUES (?, ?, ?, $now, $now)",
+            [$cat_id, $name, $parent_id]
+        );
+
+        // Update hierarchy
+        \news_admin_ops::UpdateHierarchyPositions();
+
+        echo "Created category $cat_id ($name)\n";
+    }
+}

--- a/modules/News/lib/Commands/class.CategoryDeleteCommand.php
+++ b/modules/News/lib/Commands/class.CategoryDeleteCommand.php
@@ -1,0 +1,65 @@
+<?php
+namespace News\Commands;
+use CMSMS\CLI\App;
+use CMSMS\CLI\GetOptExt\Command;
+use CMSMS\CLI\GetOptExt\Option;
+use CMSMS\CLI\GetOptExt\GetOpt;
+use GetOpt\Operand;
+
+class CategoryDeleteCommand extends Command
+{
+    public function __construct(App $app)
+    {
+        parent::__construct($app, 'news-category-delete');
+        $this->addOperand(new Operand('category', Operand::REQUIRED));
+        $this->addOption(Option::Create(null, 'force')->setDescription('Force delete even if category has articles'));
+    }
+
+    public function getShortDescription()
+    {
+        return 'Delete a News category';
+    }
+
+    public function getLongDescription()
+    {
+        return 'Delete a News category by ID or name. Refuses if articles exist unless --force is used.';
+    }
+
+    public function handle()
+    {
+        $category = trim($this->getOperand('category')->getValue());
+        $force = $this->getOption('force')->getValue();
+
+        $db = \cmsms()->GetDb();
+        $prefix = \cms_db_prefix();
+
+        // Resolve category
+        if (is_numeric($category)) {
+            $row = $db->GetRow("SELECT news_category_id, news_category_name FROM {$prefix}module_news_categories WHERE news_category_id = ?", [(int) $category]);
+        } else {
+            $row = $db->GetRow("SELECT news_category_id, news_category_name FROM {$prefix}module_news_categories WHERE news_category_name = ?", [$category]);
+        }
+        if (!$row) throw new \RuntimeException("Category '$category' not found");
+        $cat_id = (int) $row['news_category_id'];
+
+        // Check for articles in this category
+        $count = (int) $db->GetOne("SELECT COUNT(*) FROM {$prefix}module_news WHERE news_category_id = ?", [$cat_id]);
+        if ($count > 0 && !$force) {
+            throw new \RuntimeException("Category '{$row['news_category_name']}' has $count article(s). Use --force to delete anyway.");
+        }
+
+        // If force, move articles to first available category
+        if ($count > 0) {
+            $fallback = $db->GetOne("SELECT news_category_id FROM {$prefix}module_news_categories WHERE news_category_id != ? ORDER BY news_category_id LIMIT 1", [$cat_id]);
+            if ($fallback) {
+                $db->Execute("UPDATE {$prefix}module_news SET news_category_id = ? WHERE news_category_id = ?", [(int) $fallback, $cat_id]);
+                echo "Moved $count article(s) to category $fallback\n";
+            }
+        }
+
+        $db->Execute("DELETE FROM {$prefix}module_news_categories WHERE news_category_id = ?", [$cat_id]);
+        \news_admin_ops::UpdateHierarchyPositions();
+
+        echo "Deleted category $cat_id ({$row['news_category_name']})\n";
+    }
+}

--- a/modules/News/lib/Commands/class.CategoryEditCommand.php
+++ b/modules/News/lib/Commands/class.CategoryEditCommand.php
@@ -1,0 +1,83 @@
+<?php
+namespace News\Commands;
+use CMSMS\CLI\App;
+use CMSMS\CLI\GetOptExt\Command;
+use CMSMS\CLI\GetOptExt\Option;
+use CMSMS\CLI\GetOptExt\GetOpt;
+use GetOpt\Operand;
+
+class CategoryEditCommand extends Command
+{
+    public function __construct(App $app)
+    {
+        parent::__construct($app, 'news-category-edit');
+        $this->addOperand(new Operand('category', Operand::REQUIRED));
+        $this->addOption(Option::Create(null, 'name', GetOpt::REQUIRED_ARGUMENT)->setDescription('Set category name'));
+        $this->addOption(Option::Create(null, 'parent', GetOpt::REQUIRED_ARGUMENT)->setDescription('Set parent category name or ID (-1 for root)'));
+    }
+
+    public function getShortDescription()
+    {
+        return 'Edit a News category';
+    }
+
+    public function getLongDescription()
+    {
+        return 'Update a News category name or parent by ID or name';
+    }
+
+    public function handle()
+    {
+        $category = trim($this->getOperand('category')->getValue());
+        $new_name = $this->getOption('name')->getValue();
+        $parent = $this->getOption('parent')->getValue();
+
+        if ($new_name === null && $parent === null) {
+            throw new \RuntimeException('Please specify --name or --parent to change');
+        }
+
+        $db = \cmsms()->GetDb();
+        $prefix = \cms_db_prefix();
+
+        // Resolve category
+        if (is_numeric($category)) {
+            $row = $db->GetRow("SELECT news_category_id, news_category_name FROM {$prefix}module_news_categories WHERE news_category_id = ?", [(int) $category]);
+        } else {
+            $row = $db->GetRow("SELECT news_category_id, news_category_name FROM {$prefix}module_news_categories WHERE news_category_name = ?", [$category]);
+        }
+        if (!$row) throw new \RuntimeException("Category '$category' not found");
+        $cat_id = (int) $row['news_category_id'];
+
+        $updates = [];
+        $params = [];
+        $now = $db->DbTimeStamp(time());
+
+        if ($new_name !== null) { $updates[] = 'news_category_name = ?'; $params[] = $new_name; }
+
+        if ($parent !== null) {
+            if ($parent == '-1') {
+                $parent_id = -1;
+            } elseif (is_numeric($parent)) {
+                $check = $db->GetOne("SELECT news_category_id FROM {$prefix}module_news_categories WHERE news_category_id = ?", [(int) $parent]);
+                if (!$check) throw new \RuntimeException("Parent category ID '$parent' not found");
+                $parent_id = (int) $parent;
+            } else {
+                $check = $db->GetOne("SELECT news_category_id FROM {$prefix}module_news_categories WHERE news_category_name = ?", [$parent]);
+                if (!$check) throw new \RuntimeException("Parent category '$parent' not found");
+                $parent_id = (int) $check;
+            }
+            $updates[] = 'parent_id = ?';
+            $params[] = $parent_id;
+        }
+
+        $updates[] = "modified_date = $now";
+        $params[] = $cat_id;
+
+        $db->Execute("UPDATE {$prefix}module_news_categories SET " . implode(', ', $updates) . " WHERE news_category_id = ?", $params);
+
+        // Update hierarchy
+        \news_admin_ops::UpdateHierarchyPositions();
+
+        echo "Updated category $cat_id\n";
+    }
+}

--- a/modules/News/lib/Commands/class.CategoryListCommand.php
+++ b/modules/News/lib/Commands/class.CategoryListCommand.php
@@ -1,0 +1,59 @@
+<?php
+namespace News\Commands;
+use CMSMS\CLI\App;
+use CMSMS\CLI\GetOptExt\Command;
+use CMSMS\CLI\GetOptExt\Option;
+use CMSMS\CLI\GetOptExt\GetOpt;
+
+class CategoryListCommand extends Command
+{
+    public function __construct(App $app)
+    {
+        parent::__construct($app, 'news-category-list');
+        $this->addOption(Option::Create(null, 'output-json')->setDescription('Output in JSON format'));
+    }
+
+    public function getShortDescription()
+    {
+        return 'List News categories';
+    }
+
+    public function getLongDescription()
+    {
+        return 'Display all News categories with their ID, name, and parent';
+    }
+
+    public function handle()
+    {
+        $json = $this->getOption('output-json')->getValue();
+
+        $db = \cmsms()->GetDb();
+        $prefix = \cms_db_prefix();
+
+        $rows = $db->GetArray("SELECT news_category_id, news_category_name, parent_id, item_order FROM {$prefix}module_news_categories ORDER BY item_order, news_category_name");
+
+        if (empty($rows)) {
+            if (!$json) echo "No categories found.\n";
+            return;
+        }
+
+        if ($json) {
+            $out = [];
+            foreach ($rows as $row) {
+                $row['news_category_id'] = (int) $row['news_category_id'];
+                $row['parent_id'] = (int) $row['parent_id'];
+                $row['item_order'] = (int) $row['item_order'];
+                $out[] = $row;
+            }
+            echo json_encode($out, JSON_PRETTY_PRINT) . "\n";
+            return;
+        }
+
+        $fmt = "%-5s %-40s %-10s %-5s\n";
+        printf($fmt, 'ID', 'Name', 'Parent', 'Order');
+        printf($fmt, '--', '----', '------', '-----');
+        foreach ($rows as $row) {
+            printf($fmt, $row['news_category_id'], substr($row['news_category_name'], 0, 40), $row['parent_id'], $row['item_order']);
+        }
+    }
+}

--- a/modules/News/lib/Commands/class.FielddefCreateCommand.php
+++ b/modules/News/lib/Commands/class.FielddefCreateCommand.php
@@ -1,0 +1,63 @@
+<?php
+namespace News\Commands;
+use CMSMS\CLI\App;
+use CMSMS\CLI\GetOptExt\Command;
+use CMSMS\CLI\GetOptExt\Option;
+use CMSMS\CLI\GetOptExt\GetOpt;
+use GetOpt\Operand;
+
+class FielddefCreateCommand extends Command
+{
+    public function __construct(App $app)
+    {
+        parent::__construct($app, 'news-fielddef-create');
+        $this->addOperand(new Operand('name', Operand::REQUIRED));
+        $this->addOption(Option::Create(null, 'type', GetOpt::REQUIRED_ARGUMENT)->setDescription('Field type: textbox, textarea, checkbox, dropdown, linkedfile, file (default: textbox)'));
+        $this->addOption(Option::Create(null, 'max-length', GetOpt::REQUIRED_ARGUMENT)->setDescription('Max length (default: 255)'));
+        $this->addOption(Option::Create(null, 'public')->setDescription('Make field public (visible in frontend form)'));
+        $this->addOption(Option::Create(null, 'extra', GetOpt::REQUIRED_ARGUMENT)->setDescription('Extra options (e.g. dropdown values)'));
+    }
+
+    public function getShortDescription()
+    {
+        return 'Create a News custom field definition';
+    }
+
+    public function getLongDescription()
+    {
+        return 'Create a new custom field definition for News articles. Types: textbox, textarea, checkbox, dropdown, linkedfile, file';
+    }
+
+    public function handle()
+    {
+        $name = trim($this->getOperand('name')->getValue());
+        $type = $this->getOption('type')->getValue() ?: 'textbox';
+        $max_length = $this->getOption('max-length')->getValue();
+        $public = $this->getOption('public')->getValue();
+        $extra = $this->getOption('extra')->getValue();
+
+        $valid_types = ['textbox', 'textarea', 'checkbox', 'dropdown', 'linkedfile', 'file'];
+        if (!in_array($type, $valid_types)) {
+            throw new \RuntimeException("Invalid type '$type'. Valid: " . implode(', ', $valid_types));
+        }
+
+        $db = \cmsms()->GetDb();
+        $prefix = \cms_db_prefix();
+
+        // Check duplicate
+        $exists = $db->GetOne("SELECT id FROM {$prefix}module_news_fielddefs WHERE name = ?", [$name]);
+        if ($exists) throw new \RuntimeException("Field '$name' already exists (ID: $exists)");
+
+        // Get next order
+        $max_order = (int) $db->GetOne("SELECT MAX(item_order) FROM {$prefix}module_news_fielddefs");
+        $now = $db->DbTimeStamp(time());
+
+        $db->Execute(
+            "INSERT INTO {$prefix}module_news_fielddefs (name, type, max_length, item_order, public, extra, create_date, modified_date) VALUES (?, ?, ?, ?, ?, ?, $now, $now)",
+            [$name, $type, $max_length ? (int) $max_length : 255, $max_order + 1, $public ? 1 : 0, $extra ?: '']
+        );
+
+        $fd_id = $db->Insert_ID();
+        echo "Created field definition $fd_id ($name, type: $type)\n";
+    }
+}

--- a/modules/News/lib/Commands/class.FielddefDeleteCommand.php
+++ b/modules/News/lib/Commands/class.FielddefDeleteCommand.php
@@ -1,0 +1,51 @@
+<?php
+namespace News\Commands;
+use CMSMS\CLI\App;
+use CMSMS\CLI\GetOptExt\Command;
+use CMSMS\CLI\GetOptExt\Option;
+use CMSMS\CLI\GetOptExt\GetOpt;
+use GetOpt\Operand;
+
+class FielddefDeleteCommand extends Command
+{
+    public function __construct(App $app)
+    {
+        parent::__construct($app, 'news-fielddef-delete');
+        $this->addOperand(new Operand('field', Operand::REQUIRED));
+    }
+
+    public function getShortDescription()
+    {
+        return 'Delete a News custom field definition';
+    }
+
+    public function getLongDescription()
+    {
+        return 'Delete a News custom field definition by ID or name. Also removes all stored values for that field.';
+    }
+
+    public function handle()
+    {
+        $field = trim($this->getOperand('field')->getValue());
+
+        $db = \cmsms()->GetDb();
+        $prefix = \cms_db_prefix();
+
+        // Resolve field
+        if (is_numeric($field)) {
+            $row = $db->GetRow("SELECT id, name FROM {$prefix}module_news_fielddefs WHERE id = ?", [(int) $field]);
+        } else {
+            $row = $db->GetRow("SELECT id, name FROM {$prefix}module_news_fielddefs WHERE name = ?", [$field]);
+        }
+        if (!$row) throw new \RuntimeException("Field definition '$field' not found");
+        $fd_id = (int) $row['id'];
+
+        // Delete all field values
+        $db->Execute("DELETE FROM {$prefix}module_news_fieldvals WHERE fielddef_id = ?", [$fd_id]);
+
+        // Delete the definition
+        $db->Execute("DELETE FROM {$prefix}module_news_fielddefs WHERE id = ?", [$fd_id]);
+
+        echo "Deleted field definition $fd_id ({$row['name']})\n";
+    }
+}

--- a/modules/News/lib/Commands/class.FielddefEditCommand.php
+++ b/modules/News/lib/Commands/class.FielddefEditCommand.php
@@ -1,0 +1,81 @@
+<?php
+namespace News\Commands;
+use CMSMS\CLI\App;
+use CMSMS\CLI\GetOptExt\Command;
+use CMSMS\CLI\GetOptExt\Option;
+use CMSMS\CLI\GetOptExt\GetOpt;
+use GetOpt\Operand;
+
+class FielddefEditCommand extends Command
+{
+    public function __construct(App $app)
+    {
+        parent::__construct($app, 'news-fielddef-edit');
+        $this->addOperand(new Operand('field', Operand::REQUIRED));
+        $this->addOption(Option::Create(null, 'name', GetOpt::REQUIRED_ARGUMENT)->setDescription('Set field name'));
+        $this->addOption(Option::Create(null, 'type', GetOpt::REQUIRED_ARGUMENT)->setDescription('Set field type'));
+        $this->addOption(Option::Create(null, 'max-length', GetOpt::REQUIRED_ARGUMENT)->setDescription('Set max length'));
+        $this->addOption(Option::Create(null, 'public', GetOpt::REQUIRED_ARGUMENT)->setDescription('Set public: 1 or 0'));
+        $this->addOption(Option::Create(null, 'extra', GetOpt::REQUIRED_ARGUMENT)->setDescription('Set extra options'));
+    }
+
+    public function getShortDescription()
+    {
+        return 'Edit a News custom field definition';
+    }
+
+    public function getLongDescription()
+    {
+        return 'Update a News custom field definition by ID or name';
+    }
+
+    public function handle()
+    {
+        $field = trim($this->getOperand('field')->getValue());
+        $new_name = $this->getOption('name')->getValue();
+        $type = $this->getOption('type')->getValue();
+        $max_length = $this->getOption('max-length')->getValue();
+        $public = $this->getOption('public')->getValue();
+        $extra = $this->getOption('extra')->getValue();
+
+        if ($new_name === null && $type === null && $max_length === null && $public === null && $extra === null) {
+            throw new \RuntimeException('Please specify at least one option to change');
+        }
+
+        $db = \cmsms()->GetDb();
+        $prefix = \cms_db_prefix();
+
+        // Resolve field
+        if (is_numeric($field)) {
+            $row = $db->GetRow("SELECT id, name FROM {$prefix}module_news_fielddefs WHERE id = ?", [(int) $field]);
+        } else {
+            $row = $db->GetRow("SELECT id, name FROM {$prefix}module_news_fielddefs WHERE name = ?", [$field]);
+        }
+        if (!$row) throw new \RuntimeException("Field definition '$field' not found");
+        $fd_id = (int) $row['id'];
+
+        if ($type) {
+            $valid_types = ['textbox', 'textarea', 'checkbox', 'dropdown', 'linkedfile', 'file'];
+            if (!in_array($type, $valid_types)) {
+                throw new \RuntimeException("Invalid type '$type'. Valid: " . implode(', ', $valid_types));
+            }
+        }
+
+        $updates = [];
+        $params = [];
+        $now = $db->DbTimeStamp(time());
+
+        if ($new_name !== null) { $updates[] = 'name = ?'; $params[] = $new_name; }
+        if ($type !== null) { $updates[] = 'type = ?'; $params[] = $type; }
+        if ($max_length !== null) { $updates[] = 'max_length = ?'; $params[] = (int) $max_length; }
+        if ($public !== null) { $updates[] = 'public = ?'; $params[] = (int) $public; }
+        if ($extra !== null) { $updates[] = 'extra = ?'; $params[] = $extra; }
+
+        $updates[] = "modified_date = $now";
+        $params[] = $fd_id;
+
+        $db->Execute("UPDATE {$prefix}module_news_fielddefs SET " . implode(', ', $updates) . " WHERE id = ?", $params);
+
+        echo "Updated field definition $fd_id\n";
+    }
+}

--- a/modules/News/lib/Commands/class.FielddefListCommand.php
+++ b/modules/News/lib/Commands/class.FielddefListCommand.php
@@ -1,0 +1,60 @@
+<?php
+namespace News\Commands;
+use CMSMS\CLI\App;
+use CMSMS\CLI\GetOptExt\Command;
+use CMSMS\CLI\GetOptExt\Option;
+use CMSMS\CLI\GetOptExt\GetOpt;
+
+class FielddefListCommand extends Command
+{
+    public function __construct(App $app)
+    {
+        parent::__construct($app, 'news-fielddef-list');
+        $this->addOption(Option::Create(null, 'output-json')->setDescription('Output in JSON format'));
+    }
+
+    public function getShortDescription()
+    {
+        return 'List News custom field definitions';
+    }
+
+    public function getLongDescription()
+    {
+        return 'Display all custom field definitions for News articles';
+    }
+
+    public function handle()
+    {
+        $json = $this->getOption('output-json')->getValue();
+
+        $db = \cmsms()->GetDb();
+        $prefix = \cms_db_prefix();
+
+        $rows = $db->GetArray("SELECT id, name, type, max_length, item_order, public FROM {$prefix}module_news_fielddefs ORDER BY item_order");
+
+        if (empty($rows)) {
+            if (!$json) echo "No field definitions found.\n";
+            return;
+        }
+
+        if ($json) {
+            $out = [];
+            foreach ($rows as $row) {
+                $row['id'] = (int) $row['id'];
+                $row['max_length'] = (int) $row['max_length'];
+                $row['item_order'] = (int) $row['item_order'];
+                $row['public'] = (int) $row['public'];
+                $out[] = $row;
+            }
+            echo json_encode($out, JSON_PRETTY_PRINT) . "\n";
+            return;
+        }
+
+        $fmt = "%-5s %-30s %-12s %-10s %-6s %-6s\n";
+        printf($fmt, 'ID', 'Name', 'Type', 'MaxLen', 'Order', 'Public');
+        printf($fmt, '--', '----', '----', '------', '-----', '------');
+        foreach ($rows as $row) {
+            printf($fmt, $row['id'], substr($row['name'], 0, 30), $row['type'], $row['max_length'] ?: '-', $row['item_order'], $row['public']);
+        }
+    }
+}


### PR DESCRIPTION
Adds 12 CLI commands to the News module via the `clicommands` capability, enabling full CRUD operations from the command line using cmscli.

## Commands

**Articles:**
- `news-list` — List articles (filter by category, status)
- `news-create <title>` — Create article with content, URL, category, custom fields
- `news-edit <id|slug>` — Edit any article field
- `news-delete <id|slug>` — Delete article + field values + static route

**Categories:**
- `news-category-list` — List all categories
- `news-category-create <name>` — Create category
- `news-category-edit <id|name>` — Rename or reparent
- `news-category-delete <id|name>` — Delete (with --force for non-empty)

**Field Definitions:**
- `news-fielddef-list` — List custom field definitions
- `news-fielddef-create <name>` — Create field (textbox, textarea, etc.)
- `news-fielddef-edit <id|name>` — Edit field properties
- `news-fielddef-delete <id|name>` — Delete field + all values

## Usage

```bash
cmscli news-list --category Blog --output-json
cmscli news-create "My Article" --url my-article --category Blog --content "<p>Hello</p>"
cmscli news-edit my-article --title "Updated" --set-field meta_description="New meta"
cmscli news-delete my-article
```

Follows the same pattern as LISE CLI commands. Requires cmscli 2.0+.
